### PR TITLE
Update manifests to be consistent with terraform >= 0.12

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,23 +1,23 @@
 module "label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  name       = "${var.name}"
-  delimiter  = "${var.delimiter}"
-  attributes = "${var.attributes}"
-  tags       = "${var.tags}"
+  namespace  = var.namespace
+  stage      = var.stage
+  name       = var.name
+  delimiter  = var.delimiter
+  attributes = var.attributes
+  tags       = var.tags
 }
 
 resource "aws_iam_instance_profile" "default" {
-  name = "${module.label.id}"
-  role = "${aws_iam_role.default.name}"
+  name = module.label.id
+  role = aws_iam_role.default.name
 }
 
 resource "aws_iam_role" "default" {
-  name = "${module.label.id}"
+  name = module.label.id
   path = "/"
 
-  assume_role_policy = "${data.aws_iam_policy_document.default.json}"
+  assume_role_policy = data.aws_iam_policy_document.default.json
 }
 
 data "aws_iam_policy_document" "default" {
@@ -38,25 +38,25 @@ data "aws_iam_policy_document" "default" {
 }
 
 resource "aws_security_group" "default" {
-  name        = "${module.label.id}"
-  vpc_id      = "${var.vpc_id}"
+  name        = module.label.id
+  vpc_id      = var.vpc_id
   description = "Bastion security group (only SSH inbound access is allowed)"
 
-  tags = "${module.label.tags}"
+  tags = module.label.tags
 
   ingress {
     protocol  = "tcp"
     from_port = 22
     to_port   = 22
 
-    cidr_blocks = ["${var.allowed_cidr_blocks}"]
+    cidr_blocks = [var.allowed_cidr_blocks]
   }
 
   ingress {
     from_port       = 0
     to_port         = 0
     protocol        = -1
-    security_groups = ["${var.security_groups}"]
+    security_groups = var.security_groups
   }
 
   lifecycle {
@@ -65,49 +65,47 @@ resource "aws_security_group" "default" {
 }
 
 data "aws_route53_zone" "domain" {
-  count   = "${var.zone_id != "" ? 1 : 0}"
-  zone_id = "${var.zone_id}"
+  count   = var.zone_id != "" ? 1 : 0
+  zone_id = var.zone_id
 }
 
 data "template_file" "user_data" {
-  template = "${file("${path.module}/user_data.sh")}"
+  template = file("${path.module}/user_data.sh")
 
-  vars {
-    user_data       = "${join("\n", var.user_data)}"
-    welcome_message = "${var.stage}"
-    hostname        = "${var.name}.${join("",data.aws_route53_zone.domain.*.name)}"
-    search_domains  = "${join("",data.aws_route53_zone.domain.*.name)}"
-    ssh_user        = "${var.ssh_user}"
+  vars = {
+    user_data       = join("\n", var.user_data)
+    welcome_message = var.stage
+    hostname        = "${var.name}.${join("", data.aws_route53_zone.domain.*.name)}"
+    search_domains  = join("", data.aws_route53_zone.domain.*.name)
+    ssh_user        = var.ssh_user
   }
 }
 
 resource "aws_instance" "default" {
-  ami           = "${var.ami}"
-  instance_type = "${var.instance_type}"
+  ami           = var.ami
+  instance_type = var.instance_type
 
-  user_data = "${data.template_file.user_data.rendered}"
+  user_data = data.template_file.user_data.rendered
 
-  vpc_security_group_ids = [
-    "${compact(concat(list(aws_security_group.default.id), var.security_groups))}",
-  ]
+  vpc_security_group_ids = compact(concat(list(aws_security_group.default.id), var.security_groups))
 
-  iam_instance_profile        = "${aws_iam_instance_profile.default.name}"
+  iam_instance_profile        = aws_iam_instance_profile.default.name
   associate_public_ip_address = "true"
 
-  key_name = "${var.key_name}"
+  key_name = var.key_name
 
-  subnet_id = "${var.subnets[0]}"
+  subnet_id = var.subnets[0]
 
-  tags = "${module.label.tags}"
+  tags = module.label.tags
 }
 
 module "dns" {
-  enabled   = "${var.zone_id != "" ? true : false }"
+  enabled   = var.zone_id != "" ? true : false
   source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.2.5"
-  namespace = "${var.namespace}"
-  name      = "${var.name}"
-  stage     = "${var.stage}"
-  zone_id   = "${var.zone_id}"
+  namespace = var.namespace
+  name      = var.name
+  stage     = var.stage
+  zone_id   = var.zone_id
   ttl       = 60
-  records   = ["${aws_instance.default.public_dns}"]
+  records   = [aws_instance.default.public_dns]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,29 +1,30 @@
 output "instance_id" {
-  value       = "${aws_instance.default.id}"
+  value       = aws_instance.default.id
   description = "Instance ID"
 }
 
 output "ssh_user" {
-  value       = "${var.ssh_user}"
+  value       = var.ssh_user
   description = "SSH user"
 }
 
 output "security_group_id" {
-  value       = "${aws_security_group.default.id}"
+  value       = aws_security_group.default.id
   description = "Security group ID"
 }
 
 output "role" {
-  value       = "${aws_iam_role.default.name}"
+  value       = aws_iam_role.default.name
   description = "Name of AWS IAM Role associated with the instance"
 }
 
 output "public_ip" {
-  value       = "${aws_instance.default.public_ip}"
+  value       = aws_instance.default.public_ip
   description = "Public IP of the instance (or EIP)"
 }
 
 output "private_ip" {
-  value       = "${aws_instance.default.private_ip}"
+  value       = aws_instance.default.private_ip
   description = "Private IP of the instance"
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,97 +1,96 @@
 variable "namespace" {
   description = "Namespace (e.g. `eg` or `cp`)"
-  type        = "string"
+  type        = string
 }
 
 variable "stage" {
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
-  type        = "string"
+  type        = string
 }
 
 variable "name" {
   description = "Name  (e.g. `app` or `bastion`)"
-  type        = "string"
+  type        = string
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Additional attributes (e.g. `1`)"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags (e.g. map('BusinessUnit`,`XYZ`)"
 }
 
 variable "zone_id" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Route53 DNS Zone ID"
 }
 
 variable "instance_type" {
-  type        = "string"
+  type        = string
   default     = "t2.micro"
   description = "Elastic cache instance type"
 }
 
 variable "ami" {
-  type        = "string"
+  type        = string
   default     = "ami-efd0428f"
   description = "AMI to use"
 }
 
 variable "vpc_id" {
-  type        = "string"
+  type        = string
   description = "VPC ID"
 }
 
 variable "subnets" {
-  type        = "list"
+  type        = list(string)
   description = "AWS subnet IDs"
 }
 
 variable "user_data" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "User data content"
 }
 
 variable "key_name" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Key name"
 }
 
 variable "ssh_user" {
-  type        = "string"
+  type        = string
   description = "Default SSH user for this AMI. e.g. `ec2user` for Amazon Linux and `ubuntu` for Ubuntu systems"
 }
 
 variable "security_groups" {
-  type        = "list"
+  type        = list(string)
   description = "AWS security group IDs"
 }
 
 variable "allowed_cidr_blocks" {
-  type        = "list"
+  //  type        = "list"
   description = "A list of CIDR blocks allowed to connect"
 
-  default = [
-    "0.0.0.0/0",
-  ]
+  default = "0.0.0.0/0"
 }
 
 variable "user_data_file" {
-  type        = "string"
+  type        = string
   default     = "user_data.sh"
   description = "User data file"
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
## What
* Update code to be valid for terraform version >=0.12 (tested on Terraform v0.12.12)

## Why
* Current manifests issues errors in terraform >=0.12